### PR TITLE
Add Google Analytics (gtag) to root layout using next/script

### DIFF
--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -4,6 +4,7 @@ import { I18nProvider } from "./providers/I18nProvider";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import type { Metadata } from "next";
+import Script from "next/script";
 import { SEGMENT_TO_LANG } from "@/lib/lang";
 
 export const metadata: Metadata = {
@@ -80,6 +81,18 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <meta name="color-scheme" content="dark light" />
         {/* Set theme & lang before paint */}
         <script dangerouslySetInnerHTML={{ __html: bootScript }} />
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-4D4N3LYB13"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-4D4N3LYB13');
+          `}
+        </Script>
       </head>
       <body className="app-shell">
         <I18nProvider>{children}</I18nProvider>


### PR DESCRIPTION
### Motivation

- Add Google Analytics globally so pages are tracked with measurement ID `G-4D4N3LYB13`.
- Load the analytics script in a Next.js-friendly way to avoid blocking paint and to run only after hydration.

### Description

- Imported `Script` from `next/script` and updated `www/app/layout.tsx` to include Google Tag scripts in the document `<head>`.
- Added a `<Script src="https://www.googletagmanager.com/gtag/js?id=G-4D4N3LYB13" strategy="afterInteractive" />` to load `gtag.js`.
- Added an inline `<Script id="google-analytics" strategy="afterInteractive">` that initializes `dataLayer`, defines `gtag`, and calls `gtag('config', 'G-4D4N3LYB13')`.

### Testing

- Ran the test suite with `cd www && npm test` and all automated tests passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0a677d580832396237b9c44d06323)