### PR TITLE
Add AdSense meta tag and default Google Consent Mode for ads

### DIFF
--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -79,10 +79,33 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="color-scheme" content="dark light" />
+        <meta
+          name="google-adsense-account"
+          content="ca-pub-2004312209927228"
+        />
         {/* Set theme & lang before paint */}
         <script dangerouslySetInnerHTML={{ __html: bootScript }} />
+        <Script id="google-consent-default" strategy="beforeInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('consent', 'default', {
+              ad_storage: 'denied',
+              ad_user_data: 'denied',
+              ad_personalization: 'denied',
+              analytics_storage: 'denied',
+              wait_for_update: 500
+            });
+          `}
+        </Script>
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-4D4N3LYB13"
+          strategy="afterInteractive"
+        />
+        <Script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2004312209927228"
+          crossOrigin="anonymous"
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">


### PR DESCRIPTION
### Motivation
- Prepare the site for serving Google ads by advertising the AdSense publisher ID and ensuring Consent Mode starts in a safe default state until the CMP updates consent.
- Ensure AdSense script is loaded so ads can initialize once consent is granted.

### Description
- Added a `google-adsense-account` meta tag to the global head in `www/app/layout.tsx` with the publisher ID `ca-pub-2004312209927228`.
- Injected a `beforeInteractive` script (`id="google-consent-default"`) that calls `gtag('consent', 'default', ...)` and sets `ad_storage`, `ad_user_data`, `ad_personalization`, and `analytics_storage` to `'denied'` and `wait_for_update: 500`.
- Added the AdSense loader script (`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2004312209927228`) with `async` and `crossOrigin="anonymous"` to the layout so ads can initialize after interactive load.

### Testing
- Ran `npm run test` and all tests passed (`3` tests, `0` failures).
- Ran `npm run lint` but the Next.js ESLint setup launched an interactive configuration prompt in this environment, so linting did not complete non-interactively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5c93142c8323938e59cfca502fb9)