### PR TITLE
Add Google Ads/FundingChoices & update privacy/about translations across locales

### DIFF
--- a/www/app/layout.tsx
+++ b/www/app/layout.tsx
@@ -79,10 +79,58 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="color-scheme" content="dark light" />
+        <meta
+          name="google-adsense-account"
+          content="ca-pub-2004312209927228"
+        />
         {/* Set theme & lang before paint */}
         <script dangerouslySetInnerHTML={{ __html: bootScript }} />
+        <Script id="google-consent-default" strategy="beforeInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('consent', 'default', {
+              ad_storage: 'denied',
+              ad_user_data: 'denied',
+              ad_personalization: 'denied',
+              analytics_storage: 'denied',
+              wait_for_update: 500
+            });
+          `}
+        </Script>
+        <Script
+          async
+          src="https://fundingchoicesmessages.google.com/i/pub-2004312209927228?ers=1"
+          strategy="beforeInteractive"
+        />
+        <Script id="google-funding-choices-presence" strategy="beforeInteractive">
+          {`
+            (function () {
+              function signalGooglefcPresent() {
+                if (!window.frames["googlefcPresent"]) {
+                  if (document.body) {
+                    var iframe = document.createElement("iframe");
+                    iframe.style.cssText =
+                      "width:0;height:0;border:none;z-index:-1000;left:-1000px;top:-1000px;display:none;";
+                    iframe.name = "googlefcPresent";
+                    document.body.appendChild(iframe);
+                  } else {
+                    setTimeout(signalGooglefcPresent, 0);
+                  }
+                }
+              }
+              signalGooglefcPresent();
+            })();
+          `}
+        </Script>
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-4D4N3LYB13"
+          strategy="afterInteractive"
+        />
+        <Script
+          async
+          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2004312209927228"
+          crossOrigin="anonymous"
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">

--- a/www/public/ads.txt
+++ b/www/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2004312209927228, DIRECT, f08c47fec0942fa0

--- a/www/public/locales/ar.json
+++ b/www/public/locales/ar.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "تم إنشاؤه بواسطة DMZ DATA AS",
-    "intro": "تم الإنشاء في بورسكرون، النرويج.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "اتصال",
-      "p1": "المسؤول عن www.sleep-test.org هو DMZ DATA AS. نقطة الاتصال لأسئلة الخصوصية والأسئلة العامة: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org أداة للتقرير الذاتي عن عادات النوم والتحديات المرتبطة بالنوم. تستند الأسئلة والتوصيات إلى أبحاث النوم الراسخة، والإرشادات السريرية، والمصادر الصحية المتاحة للعامة في طب النوم والصحة العامة. تهدف الخدمة إلى الإرشاد ودعم التأمل في النوم، وليست أداة تشخيصية.",
       "p4": "تشمل المواد والخلفيات المرجعية على سبيل المثال American Academy of Sleep Medicine (AASM) وNational Institutes of Health (NIH) وCenters for Disease Control and Prevention (CDC) وNational Health Service (NHS)، بالإضافة إلى أبحاث حول نظافة النوم والإيقاع اليومي والأرق. لمزيد من الخلفية المهنية والمصادر، راجع مقالات الموقع."
     }
   },
   "privacy": {
     "title": "سياسة الخصوصية",
-    "p1": "نحن نأخذ الخصوصية بجدية. تشرح هذه السياسة كيف نتعامل مع المعلومات عند استخدامك www.sleep-test.org. باستخدام الموقع، فإنك تؤكد أنك قرأت ووافقت على هذه الشروط. تم تصميم الموقع بحيث يمكن للمدارس استخدامه دون تقديم أي معلومات شخصية.",
-    "li1": "ما البيانات التي نعالجها: نحن لا نجمع الأسماء أو عناوين البريد الإلكتروني أو أي معلومات أخرى يمكن تحديدها مباشرة. لعرض وتذكر النتائج، يتم تخزين معرّف تم إنشاؤه بواسطة النظام مع ملخص للإجابات فقط. لا نستخدم ملفات تعريف الارتباط التسويقية أو نصوص التتبع الخاصة بأطراف ثالثة أو إنشاء ملفات تعريفية.",
-    "li2": "الغرض والأساس القانوني: الغرض هو توفير الخدمة وتحسين جودتها. الأساس القانوني هو المصلحة المشروعة (GDPR المادة 6(1)(f)) في تشغيل حل آمن وفعال دون معالجة بيانات شخصية. قد تتم معالجة السجلات التقنية لاستكشاف الأخطاء وإصلاحها والأمان.",
-    "li3": "التخزين والحذف: يتم تخزين المعرّفات التقنية وملخصات النتائج فقط طالما كان ذلك ضرورياً للغرض المحدد. إذا كنت تعتقد أن المحتوى يجب حذفه، يمكنك الاتصال بنا على kontor@dmz.no.",
-    "li4": "المشاركة والنقل: نحن لا نشارك البيانات مع أطراف ثالثة. إذا استخدمنا مقاولين فرعيين (معالجي بيانات) للتشغيل، فسوف يكونون ملزمين تعاقدياً بحماية البيانات وعدم استخدامها لأغراضهم الخاصة.",
-    "li5": "استخدام المدارس والأطفال: يمكن استخدام الخدمة في المدارس دون تقديم بيانات الطلاب. يمكن للمعلمين والطلاب قراءة الموقع واستخدامه دون تسجيل. لا تتم معالجة أي بيانات شخصية تتجاوز ما هو ضروري تماماً للتشغيل التقني.",
-    "li6": "ملفات تعريف الارتباط: نحن لا نستخدم ملفات تعريف الارتباط غير الضرورية. إذا أدخلنا في المستقبل ملفات تعريف ارتباط وظيفية (مثل تفضيل اللغة)، فسنحدّث هذه السياسة ونطلب الموافقة عند الضرورة.",
-    "li7": "حقوقك والاتصال: إذا كانت لديك أسئلة، أو ترغب في الوصول إلى معلومات تقنية، أو طلب الحذف، فاتصل بنا على kontor@dmz.no. يمكنك أيضاً تقديم شكوى إلى هيئة حماية البيانات النرويجية (Datatilsynet).",
-    "li8": "التغييرات: قد نقوم بتحديث هذه السياسة عند الحاجة. سيتم نشر التغييرات الهامة هنا."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "اختبار النوم",

--- a/www/public/locales/de.json
+++ b/www/public/locales/de.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "Erstellt von DMZ DATA AS",
-    "intro": "Entwickelt in Porsgrunn, Norwegen.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Kontakt",
-      "p1": "Verantwortlich für www.sleep-test.org ist DMZ DATA AS. Kontaktstelle für Datenschutzanfragen und allgemeine Fragen: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org ist ein Selbstauskunfts-Tool zu Schlafgewohnheiten und schlafbezogenen Herausforderungen. Die Fragen und Empfehlungen sind inspiriert von etablierter Schlafforschung, klinischen Leitlinien und öffentlich zugänglichen Gesundheitsquellen aus Schlafmedizin und Public Health. Der Dienst dient der Orientierung und Unterstützung bei der Reflexion über Schlaf und ist kein diagnostisches Werkzeug.",
       "p4": "Hintergrundmaterial und Inspiration umfassen unter anderem die American Academy of Sleep Medicine (AASM), die National Institutes of Health (NIH), die Centers for Disease Control and Prevention (CDC), den National Health Service (NHS) sowie Forschung zu Schlafhygiene, zirkadianem Rhythmus und Insomnie. Für ausführlichere fachliche Hintergründe und Quellen siehe die Artikel auf der Website."
     }
   },
   "privacy": {
     "title": "Datenschutzrichtlinie",
-    "p1": "Wir nehmen Datenschutz ernst. Diese Richtlinie erklärt, wie wir mit Informationen umgehen, wenn Sie www.sleep-test.org nutzen. Durch die Nutzung der Seite bestätigen Sie, dass Sie diese Bedingungen gelesen und akzeptiert haben. Die Seite ist so gestaltet, dass Schulen sie nutzen können, ohne persönliche Daten anzugeben.",
-    "li1": "Welche Daten wir verarbeiten: Wir erfassen keine Namen, E-Mail-Adressen oder andere direkt identifizierbare Informationen. Um Ergebnisse anzuzeigen und zu speichern, wird nur eine systemgenerierte ID zusammen mit einer Zusammenfassung der Antworten gespeichert. Wir verwenden keine Marketing-Cookies, keine Tracking-Skripte von Drittanbietern und kein Profiling.",
-    "li2": "Zweck und Rechtsgrundlage: Der Zweck besteht darin, den Service bereitzustellen und seine Qualität zu verbessern. Die Rechtsgrundlage ist das berechtigte Interesse (DSGVO Art. 6(1)(f)) an einem sicheren und funktionalen Betrieb ohne Verarbeitung personenbezogener Daten. Technische Protokolle können zur Fehlerbehebung und Sicherheit verarbeitet werden.",
-    "li3": "Speicherung und Löschung: Technische IDs und Ergebniszusammenfassungen werden nur so lange gespeichert, wie es für den angegebenen Zweck erforderlich ist. Wenn Sie glauben, dass Inhalte gelöscht werden sollten, können Sie uns unter kontor@dmz.no kontaktieren.",
-    "li4": "Weitergabe und Übertragung: Wir geben keine Daten an Dritte weiter. Wenn wir Subunternehmer (Datenverarbeiter) für den Betrieb einsetzen, sind sie vertraglich verpflichtet, Daten zu schützen und nicht für eigene Zwecke zu verwenden.",
-    "li5": "Schulnutzung und Kinder: Der Dienst kann in Schulen genutzt werden, ohne dass Schülerdaten angegeben werden müssen. Lehrer und Schüler können die Seite ohne Registrierung lesen und nutzen. Es werden keine personenbezogenen Daten verarbeitet, die über das technisch notwendige Maß hinausgehen.",
-    "li6": "Cookies: Wir verwenden keine unnötigen Cookies. Falls wir in Zukunft funktionale Cookies einführen (z. B. für Spracheinstellungen), werden wir diese Richtlinie aktualisieren und ggf. eine Zustimmung einholen.",
-    "li7": "Ihre Rechte und Kontakt: Wenn Sie Fragen haben, technische Informationen einsehen oder die Löschung beantragen möchten, kontaktieren Sie uns unter kontor@dmz.no. Sie können auch eine Beschwerde bei der norwegischen Datenschutzbehörde (Datatilsynet) einreichen.",
-    "li8": "Änderungen: Wir können diese Richtlinie bei Bedarf aktualisieren. Wesentliche Änderungen werden hier veröffentlicht."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Schlaftest",

--- a/www/public/locales/en.json
+++ b/www/public/locales/en.json
@@ -151,26 +151,26 @@
     }
   },
   "about": {
-    "title": "Created by DMZ DATA AS",
-    "intro": "Built in Porsgrunn, Norway.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Contact",
-      "p1": "Responsible for www.sleep-test.org is DMZ DATA AS. Contact point for privacy inquiries and general questions: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org is a self-reporting tool for sleep habits and sleep-related challenges. The questions and recommendations are inspired by established sleep research, clinical guidelines, and publicly available health sources in sleep medicine and public health. The service is intended as guidance and support for reflection on sleep, and is not a diagnostic tool.",
       "p4": "Background material and inspiration include, among others, the American Academy of Sleep Medicine (AASM), National Institutes of Health (NIH), Centers for Disease Control and Prevention (CDC), National Health Service (NHS) as well as research on sleep hygiene, circadian rhythm, and insomnia. For more detailed professional background and sources, see the articles on the website."
     }
   },
   "privacy": {
     "title": "Privacy Policy",
-    "p1": "We take privacy seriously. This policy explains how we handle information when you use www.sleep-test.org. By using the site, you confirm that you have read and accepted these terms. The site is designed so that schools can use it without providing any personal information.",
-    "li1": "What data we process: We do not collect names, email addresses, or other directly identifiable information. To display and remember results, only a system-generated ID is stored together with a summary of answers. We do not use marketing cookies, third-party tracking scripts, or profiling.",
-    "li2": "Purpose and legal basis: The purpose is to provide the service and improve its quality. The legal basis is legitimate interest (GDPR art. 6(1)(f)) in operating a secure and functional solution without processing personal data. Technical logs may be processed for troubleshooting and security.",
-    "li3": "Storage and deletion: Technical IDs and result summaries are stored only as long as necessary for the stated purpose. If you believe content should be deleted, you can contact us at kontor@dmz.no.",
-    "li4": "Sharing and transfer: We do not share data with third parties. If we use subcontractors (data processors) for operations, they will be contractually obliged to protect data and not use it for their own purposes.",
-    "li5": "School use and children: The service can be used in schools without providing student data. Teachers and students can read and use the site without registration. No personal data is processed beyond what is strictly necessary for technical operation.",
-    "li6": "Cookies: We do not use unnecessary cookies. If we in the future introduce functional cookies (e.g., for language preference), we will update this policy and request consent where required.",
-    "li7": "Your rights and contact: If you have questions, wish to access technical information, or request deletion, contact us at kontor@dmz.no. You can also lodge a complaint with the Norwegian Data Protection Authority (Datatilsynet).",
-    "li8": "Changes: We may update this policy when needed. Significant changes will be published here."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Sleep test",

--- a/www/public/locales/es.json
+++ b/www/public/locales/es.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "Creado por DMZ DATA AS",
-    "intro": "Creado en Porsgrunn, Noruega.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Contacto",
-      "p1": "El responsable de www.sleep-test.org es DMZ DATA AS. Punto de contacto para consultas de privacidad y preguntas generales: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org es una herramienta de autoinforme sobre hábitos de sueño y retos relacionados con el sueño. Las preguntas y recomendaciones se inspiran en la investigación del sueño, guías clínicas y fuentes de salud pública disponibles. El servicio pretende servir de guía y apoyo para reflexionar sobre el sueño, y no es una herramienta diagnóstica.",
       "p4": "El material de referencia e inspiración incluye, entre otros, a la American Academy of Sleep Medicine (AASM), los National Institutes of Health (NIH), los Centers for Disease Control and Prevention (CDC), el National Health Service (NHS), así como investigaciones sobre higiene del sueño, ritmo circadiano e insomnio. Para un trasfondo profesional y fuentes más detalladas, consulte los artículos del sitio."
     }
   },
   "privacy": {
     "title": "Política de privacidad",
-    "p1": "Nos tomamos la privacidad en serio. Esta política explica cómo manejamos la información cuando usas www.sleep-test.org. Al usar el sitio, confirmas que has leído y aceptado estos términos. El sitio está diseñado para que las escuelas lo usen sin proporcionar información personal.",
-    "li1": "Qué datos procesamos: No recopilamos nombres, correos electrónicos u otra información directamente identificable. Para mostrar y recordar resultados, solo se almacena una ID generada por el sistema junto con un resumen de respuestas. No utilizamos cookies de marketing, scripts de seguimiento de terceros ni elaboración de perfiles.",
-    "li2": "Propósito y base legal: El propósito es brindar el servicio y mejorar su calidad. La base legal es el interés legítimo (GDPR art. 6(1)(f)) en operar una solución segura y funcional sin procesar datos personales. Los registros técnicos pueden procesarse para resolución de problemas y seguridad.",
-    "li3": "Almacenamiento y eliminación: Las IDs técnicas y resúmenes de resultados se almacenan solo el tiempo necesario para el propósito declarado. Si crees que algún contenido debe eliminarse, puedes contactarnos en kontor@dmz.no.",
-    "li4": "Compartir y transferir: No compartimos datos con terceros. Si usamos subcontratistas (procesadores de datos) para operaciones, estarán contractualmente obligados a proteger los datos y no utilizarlos para sus propios fines.",
-    "li5": "Uso escolar y niños: El servicio puede usarse en escuelas sin proporcionar datos de estudiantes. Los maestros y estudiantes pueden leer y usar el sitio sin registro. No se procesan datos personales más allá de lo estrictamente necesario para la operación técnica.",
-    "li6": "Cookies: No utilizamos cookies innecesarias. Si en el futuro introducimos cookies funcionales (por ejemplo, para preferencias de idioma), actualizaremos esta política y solicitaremos consentimiento cuando sea necesario.",
-    "li7": "Tus derechos y contacto: Si tienes preguntas, deseas acceder a información técnica o solicitar eliminación, contáctanos en kontor@dmz.no. También puedes presentar una queja ante la Autoridad Noruega de Protección de Datos (Datatilsynet).",
-    "li8": "Cambios: Podemos actualizar esta política cuando sea necesario. Los cambios significativos se publicarán aquí."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Prueba de sueño",

--- a/www/public/locales/fr.json
+++ b/www/public/locales/fr.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "Créé par DMZ DATA AS",
-    "intro": "Créé à Porsgrunn, en Norvège.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Contact",
-      "p1": "Le responsable de www.sleep-test.org est DMZ DATA AS. Point de contact pour les questions de confidentialité et générales : kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org est un outil d’auto-évaluation des habitudes de sommeil et des difficultés liées au sommeil. Les questions et recommandations s’inspirent de la recherche sur le sommeil, de recommandations cliniques et de sources de santé publique accessibles. Le service vise à guider la réflexion sur le sommeil et n’est pas un outil de diagnostic.",
       "p4": "Les sources et inspirations incluent notamment l’American Academy of Sleep Medicine (AASM), les National Institutes of Health (NIH), les Centers for Disease Control and Prevention (CDC), le National Health Service (NHS), ainsi que des recherches sur l’hygiène du sommeil, le rythme circadien et l’insomnie. Pour davantage de références et de sources, voir les articles du site."
     }
   },
   "privacy": {
     "title": "Politique de confidentialité",
-    "p1": "Nous prenons la confidentialité au sérieux. Cette politique explique comment nous gérons les informations lorsque vous utilisez www.sleep-test.org. En utilisant le site, vous confirmez avoir lu et accepté ces conditions. Le site est conçu pour que les écoles puissent l'utiliser sans fournir d'informations personnelles.",
-    "li1": "Données que nous traitons : Nous ne collectons pas de noms, adresses e-mail ou autres informations directement identifiables. Pour afficher et mémoriser les résultats, seul un ID généré par le système est stocké avec un résumé des réponses. Nous n'utilisons pas de cookies marketing, de scripts de suivi tiers ni de profilage.",
-    "li2": "But et base légale : Le but est de fournir le service et d'en améliorer la qualité. La base légale est l'intérêt légitime (RGPD art. 6(1)(f)) d'exploiter une solution sécurisée et fonctionnelle sans traiter de données personnelles. Les journaux techniques peuvent être traités pour le dépannage et la sécurité.",
-    "li3": "Stockage et suppression : Les IDs techniques et résumés de résultats sont stockés uniquement aussi longtemps que nécessaire pour l'objectif indiqué. Si vous estimez qu'un contenu doit être supprimé, vous pouvez nous contacter à kontor@dmz.no.",
-    "li4": "Partage et transfert : Nous ne partageons pas de données avec des tiers. Si nous utilisons des sous-traitants (processeurs de données) pour les opérations, ils seront contractuellement tenus de protéger les données et de ne pas les utiliser à leurs propres fins.",
-    "li5": "Utilisation scolaire et enfants : Le service peut être utilisé dans les écoles sans fournir de données d'élèves. Les enseignants et les élèves peuvent lire et utiliser le site sans inscription. Aucune donnée personnelle n'est traitée au-delà de ce qui est strictement nécessaire pour le fonctionnement technique.",
-    "li6": "Cookies : Nous n'utilisons pas de cookies inutiles. Si nous introduisons à l'avenir des cookies fonctionnels (par ex. pour la préférence de langue), nous mettrons à jour cette politique et demanderons un consentement lorsque requis.",
-    "li7": "Vos droits et contact : Si vous avez des questions, souhaitez accéder à des informations techniques ou demander une suppression, contactez-nous à kontor@dmz.no. Vous pouvez également déposer une plainte auprès de l'Autorité norvégienne de protection des données (Datatilsynet).",
-    "li8": "Modifications : Nous pouvons mettre à jour cette politique en cas de besoin. Les changements importants seront publiés ici."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Test de sommeil",

--- a/www/public/locales/hi.json
+++ b/www/public/locales/hi.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "DMZ DATA AS द्वारा निर्मित",
-    "intro": "नॉर्वे के पोरसग्रुन में बनाया गया।",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "संपर्क करें",
-      "p1": "www.sleep-test.org के लिए जिम्मेदार DMZ DATA AS है। गोपनीयता और सामान्य प्रश्नों के लिए संपर्क बिंदु: kontor@dmz.no।",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org नींद की आदतों और नींद से जुड़ी चुनौतियों के बारे में स्व-रिपोर्टिंग टूल है। प्रश्न और सुझाव स्थापित स्लीप रिसर्च, क्लिनिकल दिशानिर्देशों और स्लीप मेडिसिन व सार्वजनिक स्वास्थ्य के खुले स्रोतों से प्रेरित हैं। यह सेवा नींद पर विचार करने में मार्गदर्शन और सहायता के लिए है, और यह निदान उपकरण नहीं है।",
       "p4": "पृष्ठभूमि सामग्री और प्रेरणा में American Academy of Sleep Medicine (AASM), National Institutes of Health (NIH), Centers for Disease Control and Prevention (CDC), National Health Service (NHS) सहित नींद स्वच्छता, सर्कैडियन रिद्म और अनिद्रा पर शोध शामिल हैं। अधिक विस्तृत पेशेवर पृष्ठभूमि और स्रोतों के लिए वेबसाइट पर लेख देखें।"
     }
   },
   "privacy": {
     "title": "गोपनीयता नीति",
-    "p1": "हम गोपनीयता को गंभीरता से लेते हैं। यह नीति बताती है कि जब आप www.sleep-test.org का उपयोग करते हैं तो हम जानकारी को कैसे संभालते हैं। साइट का उपयोग करके, आप पुष्टि करते हैं कि आपने इन शर्तों को पढ़ा और स्वीकार किया है। साइट को इस तरह डिज़ाइन किया गया है कि स्कूल इसे किसी भी व्यक्तिगत जानकारी प्रदान किए बिना उपयोग कर सकें।",
-    "li1": "हम कौन सा डेटा संसाधित करते हैं: हम नाम, ईमेल पते, या अन्य सीधे पहचान योग्य जानकारी एकत्र नहीं करते हैं। परिणाम प्रदर्शित करने और याद रखने के लिए, केवल एक सिस्टम-जनरेटेड आईडी को उत्तरों के सारांश के साथ संग्रहीत किया जाता है। हम मार्केटिंग कुकीज़, तृतीय-पक्ष ट्रैकिंग स्क्रिप्ट्स, या प्रोफाइलिंग का उपयोग नहीं करते।",
-    "li2": "उद्देश्य और कानूनी आधार: उद्देश्य सेवा प्रदान करना और इसकी गुणवत्ता में सुधार करना है। कानूनी आधार वैध हित (GDPR अनुच्छेद 6(1)(f)) है, जो व्यक्तिगत डेटा को संसाधित किए बिना एक सुरक्षित और कार्यात्मक समाधान संचालित करने में है। तकनीकी लॉग्स को समस्या निवारण और सुरक्षा के लिए संसाधित किया जा सकता है।",
-    "li3": "भंडारण और विलोपन: तकनीकी आईडी और परिणाम सारांश केवल आवश्यक अवधि तक संग्रहीत किए जाते हैं। यदि आपको लगता है कि सामग्री को हटाया जाना चाहिए, तो आप हमसे kontor@dmz.no पर संपर्क कर सकते हैं।",
-    "li4": "साझाकरण और स्थानांतरण: हम डेटा को तीसरे पक्ष के साथ साझा नहीं करते। यदि हम संचालन के लिए उप-ठेकेदारों (डेटा प्रोसेसर) का उपयोग करते हैं, तो वे अनुबंध द्वारा डेटा की रक्षा करने और इसे अपने उद्देश्यों के लिए उपयोग न करने के लिए बाध्य होंगे।",
-    "li5": "स्कूल उपयोग और बच्चे: इस सेवा का उपयोग स्कूलों में छात्र डेटा प्रदान किए बिना किया जा सकता है। शिक्षक और छात्र बिना पंजीकरण के साइट का उपयोग कर सकते हैं। तकनीकी संचालन के लिए सख्ती से आवश्यक से परे कोई व्यक्तिगत डेटा संसाधित नहीं किया जाता।",
-    "li6": "कुकीज़: हम अनावश्यक कुकीज़ का उपयोग नहीं करते। यदि भविष्य में हम कार्यात्मक कुकीज़ (जैसे भाषा प्राथमिकता के लिए) पेश करते हैं, तो हम इस नीति को अपडेट करेंगे और आवश्यक होने पर सहमति का अनुरोध करेंगे।",
-    "li7": "आपके अधिकार और संपर्क: यदि आपके प्रश्न हैं, तकनीकी जानकारी तक पहुंच चाहते हैं, या विलोपन का अनुरोध करना चाहते हैं, तो kontor@dmz.no पर हमसे संपर्क करें। आप नॉर्वेजियन डेटा संरक्षण प्राधिकरण (Datatilsynet) के पास शिकायत भी दर्ज कर सकते हैं।",
-    "li8": "परिवर्तन: हम आवश्यकता पड़ने पर इस नीति को अपडेट कर सकते हैं। महत्वपूर्ण बदलाव यहां प्रकाशित किए जाएंगे।"
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "नींद परीक्षण",

--- a/www/public/locales/ja.json
+++ b/www/public/locales/ja.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "DMZ DATA AS によって作成",
-    "intro": "ノルウェーのポースグルンで制作。",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "連絡先",
-      "p1": "www.sleep-test.org の責任者は DMZ DATA AS です。プライバシー関連のお問い合わせや一般的な質問の窓口: kontor@dmz.no。",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org は、睡眠習慣や睡眠に関する課題についての自己申告ツールです。質問と提案は、確立された睡眠研究、臨床ガイドライン、公的に利用可能な睡眠医学・公衆衛生の情報源に基づいています。このサービスは睡眠について考えるための指針とサポートを目的としており、診断ツールではありません。",
       "p4": "参考資料・インスピレーションとして、American Academy of Sleep Medicine (AASM)、National Institutes of Health (NIH)、Centers for Disease Control and Prevention (CDC)、National Health Service (NHS) などのほか、睡眠衛生、概日リズム、不眠に関する研究を含みます。詳細な専門的背景や出典については、サイト内の記事をご覧ください。"
     }
   },
   "privacy": {
     "title": "プライバシーポリシー",
-    "p1": "私たちはプライバシーを真剣に考えています。このポリシーは、www.sleep-test.org を利用する際にどのように情報を扱うかを説明します。本サイトを利用することで、あなたはこれらの条件を読んで同意したとみなされます。本サイトは、学校が個人情報を提供せずに利用できるように設計されています。",
-    "li1": "処理するデータ: 名前、メールアドレス、その他の直接識別可能な情報は収集しません。結果を表示・保存するために、システム生成のIDのみを回答の要約とともに保存します。マーケティング用クッキー、サードパーティのトラッキングスクリプト、プロファイリングは使用しません。",
-    "li2": "目的と法的根拠: サービスの提供と品質改善が目的です。法的根拠は、個人データを処理せずに安全で機能的なソリューションを運営する正当な利益（GDPR第6条1項f）です。技術的なログは、トラブルシューティングやセキュリティのために処理されることがあります。",
-    "li3": "保存と削除: 技術的IDと結果の要約は、必要な目的に限り保存されます。削除が必要だと考える場合は、kontor@dmz.no までご連絡ください。",
-    "li4": "共有と転送: データを第三者と共有しません。運営のために下請け業者（データ処理者）を利用する場合、契約によりデータ保護と第三者利用禁止を義務付けます。",
-    "li5": "学校利用と子供: 本サービスは、生徒データを提供せずに学校で利用できます。教師や生徒は登録不要で利用可能です。技術的運営に厳密に必要な範囲を超える個人データは処理しません。",
-    "li6": "クッキー: 不要なクッキーは使用しません。将来、機能的クッキー（例: 言語設定）を導入する場合、本ポリシーを更新し、必要に応じて同意を求めます。",
-    "li7": "あなたの権利と連絡先: 質問がある場合、技術情報へのアクセスや削除を希望する場合は kontor@dmz.no にご連絡ください。また、ノルウェーのデータ保護機関（Datatilsynet）に苦情を申し立てることもできます。",
-    "li8": "変更: 必要に応じて本ポリシーを更新することがあります。重要な変更はここに掲載されます。"
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "睡眠テスト",

--- a/www/public/locales/ko.json
+++ b/www/public/locales/ko.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "DMZ DATA AS 제작",
-    "intro": "노르웨이 포르스그룬에서 제작.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "연락처",
-      "p1": "www.sleep-test.org 의 책임자는 DMZ DATA AS 입니다. 개인정보 문의 및 일반 질문: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org는 수면 습관과 수면 관련 어려움에 대한 자기보고 도구입니다. 질문과 권고는 확립된 수면 연구, 임상 지침, 그리고 수면의학 및 공중보건 분야의 공개 자료에서 영감을 받았습니다. 이 서비스는 수면에 대해 성찰하도록 돕는 안내이며 진단 도구가 아닙니다.",
       "p4": "참고 자료와 영감은 American Academy of Sleep Medicine (AASM), National Institutes of Health (NIH), Centers for Disease Control and Prevention (CDC), National Health Service (NHS) 등을 포함하며, 수면 위생, 생체리듬, 불면에 관한 연구도 포함됩니다. 더 자세한 전문적 배경과 출처는 사이트의 기사에서 확인하세요."
     }
   },
   "privacy": {
     "title": "개인정보 보호정책",
-    "p1": "우리는 개인정보 보호를 진지하게 생각합니다. 이 정책은 www.sleep-test.org 를 사용할 때 정보를 어떻게 처리하는지 설명합니다. 본 사이트를 사용함으로써 귀하는 이 조건을 읽고 동의한 것으로 간주됩니다. 본 사이트는 학교에서 개인 정보를 제공하지 않고 사용할 수 있도록 설계되었습니다.",
-    "li1": "처리하는 데이터: 이름, 이메일 주소 또는 다른 직접 식별 가능한 정보를 수집하지 않습니다. 결과를 표시하고 저장하기 위해 시스템이 생성한 ID만 답변 요약과 함께 저장됩니다. 마케팅 쿠키, 제3자 추적 스크립트, 프로파일링은 사용하지 않습니다.",
-    "li2": "목적 및 법적 근거: 서비스 제공 및 품질 향상이 목적입니다. 법적 근거는 개인 데이터를 처리하지 않고 안전하고 기능적인 솔루션을 운영하기 위한 정당한 이익(GDPR 6조 1항 f)입니다. 기술 로그는 문제 해결 및 보안을 위해 처리될 수 있습니다.",
-    "li3": "저장 및 삭제: 기술적 ID와 결과 요약은 필요 목적에 한해 저장됩니다. 삭제가 필요하다고 생각되면 kontor@dmz.no 로 연락해 주세요.",
-    "li4": "공유 및 전송: 데이터를 제3자와 공유하지 않습니다. 운영을 위해 하청업체(데이터 처리자)를 사용하는 경우, 계약에 따라 데이터를 보호하고 자체 목적으로 사용하지 못하도록 합니다.",
-    "li5": "학교 사용 및 아동: 본 서비스는 학생 데이터를 제공하지 않고 학교에서 사용할 수 있습니다. 교사와 학생은 등록 없이 사이트를 읽고 사용할 수 있습니다. 기술적 운영에 엄격히 필요한 범위를 넘어서는 개인 데이터는 처리하지 않습니다.",
-    "li6": "쿠키: 불필요한 쿠키를 사용하지 않습니다. 앞으로 기능성 쿠키(예: 언어 설정)를 도입하는 경우, 본 정책을 업데이트하고 필요한 경우 동의를 요청할 것입니다.",
-    "li7": "귀하의 권리와 연락처: 질문이 있거나, 기술 정보 접근 또는 삭제를 원하면 kontor@dmz.no 로 연락해 주세요. 또한 노르웨이 데이터 보호 기관(Datatilsynet)에 불만을 제기할 수도 있습니다.",
-    "li8": "변경: 필요에 따라 본 정책을 업데이트할 수 있습니다. 중요한 변경 사항은 여기에 게시됩니다."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "수면 테스트",

--- a/www/public/locales/nb.json
+++ b/www/public/locales/nb.json
@@ -127,26 +127,26 @@
     }
   },
   "about": {
-    "title": "Laget av DMZ DATA AS",
-    "intro": "Bygget i Porsgrunn, Norge.",
+    "title": "Om Sleep Test",
+    "intro": "Sleep Test er utviklet og driftes i Norge.",
     "contact": {
       "title": "Kontakt",
-      "p1": "Ansvarlig for www.sleep-test.org er DMZ DATA AS. Kontaktpunkt for personvern og generelle henvendelser: kontor@dmz.no.",
+      "p1": "Behandlingsansvarlig for www.sleep-test.org er DMZ DATA AS. Kontakt for personvern og generelle henvendelser: kontor@dmz.no.",
       "p3": "Sleep-test.org er et selvrapporteringsverktøy for søvnvaner og søvnrelaterte utfordringer. Spørsmålene og anbefalingene er inspirert av etablert søvnforskning, kliniske retningslinjer og offentlig tilgjengelige helsekilder innen søvnmedisin og folkehelse. Tjenesten er ment som veiledning og støtte til refleksjon rundt søvn, og er ikke et diagnostisk verktøy.",
       "p4": "Bakgrunnsmateriale og inspirasjon inkluderer blant annet American Academy of Sleep Medicine (AASM), National Institutes of Health (NIH), Centers for Disease Control and Prevention (CDC), National Health Service (NHS) samt forskning på søvnhygiene, døgnrytme og insomni. For mer detaljert faglig bakgrunn og kilder, se artiklene på nettstedet."
     }
   },
   "privacy": {
     "title": "Personvernerklæring",
-    "p1": "Vi tar personvern på alvor. Denne erklæringen forklarer hvordan vi behandler opplysninger når du bruker www.sleep-test.org. Ved å bruke nettstedet bekrefter du at du har lest og akseptert disse vilkårene. Nettstedet er designet slik at skoler kan bruke tjenesten uten å oppgi personopplysninger.",
-    "li1": "Hvilke data vi behandler: Vi samler ikke inn navn, e-postadresse eller annen direkte identifiserbar informasjon. For å vise og huske resultater brukes kun en teknisk generert ID lagret sammen med en oppsummering av svarene. Vi bruker ingen markedsførings-cookies, tredjeparts sporingsskript eller profilering.",
-    "li2": "Formål og behandlingsgrunnlag: Formålet er å levere tjenesten og forbedre kvaliteten. Behandlingsgrunnlaget er berettiget interesse (GDPR art. 6(1)(f)) i å drive en sikker og velfungerende løsning uten behandling av personopplysninger. Eventuelle tekniske logger kan behandles for feilsøking og sikkerhet.",
-    "li3": "Lagring og sletting: Tekniske ID-er og resultatoppsummeringer lagres bare så lenge det er nødvendig for formålet. Dersom du mener innhold bør slettes, kan du kontakte oss på kontor@dmz.no.",
-    "li4": "Deling og overføring: Vi deler ikke data med tredjeparter. Dersom vi bruker underleverandører (databehandlere) for drift, vil de være kontraktsmessig forpliktet til å beskytte data og ikke bruke dem til egne formål.",
-    "li5": "Skolebruk og barn: Tjenesten kan brukes i skole uten å oppgi elevdata. Lærere og elever kan lese og bruke nettstedet uten registrering. Det behandles ikke personopplysninger utover det som er strengt nødvendig for teknisk drift.",
-    "li6": "Informasjonskapsler (cookies): Vi bruker ingen unødvendige cookies. Dersom vi i fremtiden innfører funksjonelle cookies (f.eks. for språkvalg), vil vi oppdatere denne erklæringen og be om samtykke der det kreves.",
-    "li7": "Dine rettigheter og kontakt: Har du spørsmål, ønsker innsyn i tekniske opplysninger, eller vil be om sletting, kontakt oss på kontor@dmz.no. Du kan også klage til Datatilsynet.",
-    "li8": "Endringer: Vi kan oppdatere denne erklæringen ved behov. Vesentlige endringer publiseres her."
+    "p1": "Vi tar personvern på alvor. Denne erklæringen forklarer hvordan opplysninger behandles når du bruker www.sleep-test.org, hvilke valg du har, og hvilke rettigheter du har etter GDPR og norsk personopplysningslovgivning.",
+    "li1": "Hvilke data vi behandler: Når du tar testen lagres en teknisk generert ID sammen med svaroppsummering for å kunne vise resultatet senere. Vi ber ikke om navn eller e-post. IP-adresse og tekniske hendelser kan behandles i sikkerhetslogger for drift og misbruksbeskyttelse.",
+    "li2": "Formål og behandlingsgrunnlag: (a) Levere og sikre tjenesten (GDPR art. 6(1)(f) berettiget interesse). (b) Måling/analyse og annonsering via Google-teknologi skjer kun basert på gyldig samtykke (GDPR art. 6(1)(a), samt ekomloven § 3-15 for lagring/tilgang på brukerutstyr).",
+    "li3": "Lagring og sletting: Test-ID og resultatsammendrag lagres så lenge det er nødvendig for formålet eller til du ber om sletting. Tekniske logger lagres i begrenset periode for sikkerhet og feilsøking.",
+    "li4": "Mottakere og overføringer: Vi bruker databehandlere for drift. Ved samtykke til analyse/annonser kan Google motta data som selvstendig eller felles behandlingsansvarlig avhengig av tjenesteoppsett. Data kan behandles utenfor EØS med relevante overføringsgrunnlag (for eksempel SCC).",
+    "li5": "Skolebruk og barn: Tjenesten kan brukes uten registrering. Vi ber om at det ikke legges inn navn eller andre direkte identifiserende opplysninger i fritekstfelt (dersom slike felter senere innføres).",
+    "li6": "Informasjonskapsler og samtykke: Nødvendige teknologier brukes for at tjenesten skal fungere. Analyse- og annonseteknologier aktiveres først etter gyldig samtykke i samtykkeløsningen. Du kan når som helst trekke samtykke tilbake ved å endre samtykkevalget ditt.",
+    "li7": "Dine rettigheter: Du kan be om innsyn, retting, sletting, begrensning, dataportabilitet og protest der vilkårene er oppfylt. Kontakt oss på kontor@dmz.no. Du kan også klage til Datatilsynet.",
+    "li8": "Endringer: Vi kan oppdatere erklæringen ved behov. Ved vesentlige endringer publiserer vi oppdatert versjon her med ny dato."
   },
   "test": {
     "title": "Søvntest",

--- a/www/public/locales/pt-BR.json
+++ b/www/public/locales/pt-BR.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "Criado por DMZ DATA AS",
-    "intro": "Criado em Porsgrunn, Noruega.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Contato",
-      "p1": "O responsável por www.sleep-test.org é a DMZ DATA AS. Ponto de contato para questões de privacidade e dúvidas gerais: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org é uma ferramenta de autorrelato sobre hábitos de sono e desafios relacionados ao sono. As perguntas e recomendações são inspiradas em pesquisas consolidadas do sono, diretrizes clínicas e fontes públicas de saúde em medicina do sono e saúde pública. O serviço serve como orientação e apoio para refletir sobre o sono e não é uma ferramenta diagnóstica.",
       "p4": "O material de referência e inspiração inclui, entre outros, a American Academy of Sleep Medicine (AASM), o National Institutes of Health (NIH), o Centers for Disease Control and Prevention (CDC), o National Health Service (NHS), além de pesquisas sobre higiene do sono, ritmo circadiano e insônia. Para mais detalhes técnicos e fontes, veja os artigos no site."
     }
   },
   "privacy": {
     "title": "Política de Privacidade",
-    "p1": "Levamos a privacidade a sério. Esta política explica como tratamos informações quando você usa www.sleep-test.org. Ao usar o site, você confirma que leu e aceitou estes termos. O site foi projetado para que escolas possam usá-lo sem fornecer informações pessoais.",
-    "li1": "Quais dados processamos: Não coletamos nomes, e-mails ou outras informações diretamente identificáveis. Para exibir e lembrar resultados, apenas um ID gerado pelo sistema é armazenado junto com um resumo das respostas. Não usamos cookies de marketing, scripts de rastreamento de terceiros ou criação de perfis.",
-    "li2": "Finalidade e base legal: O objetivo é fornecer o serviço e melhorar sua qualidade. A base legal é interesse legítimo (GDPR art. 6(1)(f)) em operar uma solução segura e funcional sem processar dados pessoais. Logs técnicos podem ser processados para resolução de problemas e segurança.",
-    "li3": "Armazenamento e exclusão: IDs técnicos e resumos de resultados são armazenados apenas pelo tempo necessário para a finalidade declarada. Se acreditar que algum conteúdo deve ser excluído, entre em contato conosco em kontor@dmz.no.",
-    "li4": "Compartilhamento e transferência: Não compartilhamos dados com terceiros. Se usarmos subcontratados (operadores de dados) para operações, eles serão contratualmente obrigados a proteger os dados e não usá-los para seus próprios fins.",
-    "li5": "Uso em escolas e crianças: O serviço pode ser usado em escolas sem fornecer dados dos alunos. Professores e alunos podem ler e usar o site sem registro. Nenhum dado pessoal é processado além do estritamente necessário para a operação técnica.",
-    "li6": "Cookies: Não usamos cookies desnecessários. Se no futuro introduzirmos cookies funcionais (ex.: preferência de idioma), atualizaremos esta política e solicitaremos consentimento, quando necessário.",
-    "li7": "Seus direitos e contato: Se tiver dúvidas, quiser acessar informações técnicas ou solicitar exclusão, entre em contato conosco em kontor@dmz.no. Você também pode registrar uma reclamação junto à Autoridade de Proteção de Dados da Noruega (Datatilsynet).",
-    "li8": "Alterações: Podemos atualizar esta política quando necessário. Alterações significativas serão publicadas aqui."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Teste de sono",

--- a/www/public/locales/ru.json
+++ b/www/public/locales/ru.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "Создано DMZ DATA AS",
-    "intro": "Создано в Порсгрунне, Норвегия.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Контакты",
-      "p1": "Ответственным за www.sleep-test.org является DMZ DATA AS. Контактное лицо для вопросов о конфиденциальности и общих вопросов: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org — инструмент самооценки привычек сна и связанных со сном трудностей. Вопросы и рекомендации основаны на признанных исследованиях сна, клинических руководствах и общедоступных источниках в области медицины сна и общественного здравоохранения. Сервис предназначен для ориентира и поддержки в размышлении о сне и не является диагностическим инструментом.",
       "p4": "В числе источников и вдохновения — American Academy of Sleep Medicine (AASM), National Institutes of Health (NIH), Centers for Disease Control and Prevention (CDC), National Health Service (NHS), а также исследования по гигиене сна, циркадным ритмам и бессоннице. Для более подробной профессиональной информации и источников см. статьи на сайте."
     }
   },
   "privacy": {
     "title": "Политика конфиденциальности",
-    "p1": "Мы серьезно относимся к конфиденциальности. Эта политика объясняет, как мы обрабатываем информацию при использовании www.sleep-test.org. Используя сайт, вы подтверждаете, что прочли и приняли эти условия. Сайт разработан так, чтобы школы могли использовать его без предоставления личной информации.",
-    "li1": "Какие данные мы обрабатываем: мы не собираем имена, адреса электронной почты или другую напрямую идентифицируемую информацию. Для отображения и сохранения результатов хранится только системный ID вместе с кратким резюме ответов. Мы не используем маркетинговые cookies, сторонние скрипты отслеживания или профилирование.",
-    "li2": "Цель и правовое основание: цель — предоставлять услугу и улучшать её качество. Правовое основание — законный интерес (GDPR ст. 6(1)(f)) в эксплуатации безопасного и функционального решения без обработки персональных данных. Технические журналы могут обрабатываться для устранения неполадок и обеспечения безопасности.",
-    "li3": "Хранение и удаление: технические ID и резюме результатов хранятся только столько, сколько необходимо для заявленной цели. Если вы считаете, что контент должен быть удален, свяжитесь с нами по адресу kontor@dmz.no.",
-    "li4": "Обмен и передача: мы не передаем данные третьим лицам. Если мы используем подрядчиков (обработчиков данных) для работы, они будут обязаны защищать данные и не использовать их для собственных целей.",
-    "li5": "Использование в школах и детьми: сервис может использоваться в школах без предоставления данных учащихся. Учителя и ученики могут читать и использовать сайт без регистрации. Персональные данные не обрабатываются сверх того, что необходимо для технической работы.",
-    "li6": "Cookies: мы не используем ненужные cookies. Если в будущем мы введем функциональные cookies (например, для предпочтений языка), мы обновим эту политику и запросим согласие, если это требуется.",
-    "li7": "Ваши права и контакты: если у вас есть вопросы, вы хотите получить доступ к технической информации или запросить удаление, свяжитесь с нами по адресу kontor@dmz.no. Вы также можете подать жалобу в Норвежское управление по защите данных (Datatilsynet).",
-    "li8": "Изменения: мы можем обновлять эту политику по мере необходимости. Существенные изменения будут опубликованы здесь."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Тест сна",

--- a/www/public/locales/sk.json
+++ b/www/public/locales/sk.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "Vytvorené spoločnosťou DMZ DATA AS",
-    "intro": "Vytvorené v Porsgrunne v Nórsku.",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "Kontakt",
-      "p1": "Za www.sleep-test.org je zodpovedná spoločnosť DMZ DATA AS. Kontakt pre otázky týkajúce sa ochrany osobných údajov a všeobecných otázok: kontor@dmz.no.",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org je nástroj na sebahodnotenie spánkových návykov a problémov súvisiacich so spánkom. Otázky a odporúčania sú inšpirované zavedeným výskumom spánku, klinickými usmerneniami a verejne dostupnými zdrojmi v spánkovej medicíne a verejnom zdraví. Služba má slúžiť ako usmernenie a podpora pri uvažovaní o spánku a nie je diagnostickým nástrojom.",
       "p4": "Podkladové materiály a inšpirácia zahŕňajú okrem iného American Academy of Sleep Medicine (AASM), National Institutes of Health (NIH), Centers for Disease Control and Prevention (CDC), National Health Service (NHS) a tiež výskum spánkovej hygieny, cirkadiánneho rytmu a insomnie. Podrobnejšie odborné pozadie a zdroje nájdete v článkoch na stránke."
     }
   },
   "privacy": {
     "title": "Zásady ochrany osobných údajov",
-    "p1": "Ochranu súkromia berieme vážne. Tieto zásady vysvetľujú, ako narábame s informáciami pri používaní www.sleep-test.org. Používaním stránky potvrdzujete, že ste si tieto podmienky prečítali a prijali. Stránka je navrhnutá tak, aby ju mohli používať školy bez poskytovania osobných údajov.",
-    "li1": "Aké údaje spracúvame: Nezbierame mená, e-mailové adresy ani iné priamo identifikovateľné informácie. Na zobrazenie a zapamätanie výsledkov sa ukladá iba systémom generované ID spolu so súhrnom odpovedí. Nepoužívame marketingové cookies, skripty tretích strán ani profilovanie.",
-    "li2": "Účel a právny základ: Účelom je poskytovať službu a zlepšovať jej kvalitu. Právnym základom je oprávnený záujem (GDPR čl. 6(1)(f)) na prevádzkovanie bezpečného a funkčného riešenia bez spracúvania osobných údajov. Technické logy môžu byť spracúvané na riešenie problémov a bezpečnosť.",
-    "li3": "Ukladanie a vymazanie: Technické ID a súhrny výsledkov sa uchovávajú iba tak dlho, ako je to potrebné na stanovený účel. Ak sa domnievate, že obsah má byť vymazaný, kontaktujte nás na kontor@dmz.no.",
-    "li4": "Zdieľanie a prenos: Údaje nezdieľame s tretími stranami. Ak používame subdodávateľov (spracovateľov údajov) na prevádzku, budú zmluvne viazaní chrániť údaje a nepoužívať ich na vlastné účely.",
-    "li5": "Používanie v školách a deťmi: Služba môže byť používaná v školách bez poskytovania údajov študentov. Učitelia a študenti môžu čítať a používať stránku bez registrácie. Osobné údaje sa nespracúvajú nad rámec toho, čo je striktne potrebné na technickú prevádzku.",
-    "li6": "Cookies: Nepoužívame zbytočné cookies. Ak v budúcnosti zavedeme funkčné cookies (napr. na jazykové preferencie), tieto zásady aktualizujeme a vyžiadame si súhlas, ak to bude potrebné.",
-    "li7": "Vaše práva a kontakt: Ak máte otázky, chcete získať prístup k technickým informáciám alebo požadujete vymazanie, kontaktujte nás na kontor@dmz.no. Môžete tiež podať sťažnosť na Nórsky úrad na ochranu osobných údajov (Datatilsynet).",
-    "li8": "Zmeny: Tieto zásady môžeme podľa potreby aktualizovať. Významné zmeny budú zverejnené tu."
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "Test spánku",

--- a/www/public/locales/zh.json
+++ b/www/public/locales/zh.json
@@ -137,26 +137,26 @@
     }
   },
   "about": {
-    "title": "由 DMZ DATA AS 创建",
-    "intro": "在挪威波尔斯格伦制作。",
+    "title": "About Sleep Test",
+    "intro": "Sleep Test is developed and operated in Norway.",
     "contact": {
       "title": "联系方式",
-      "p1": "www.sleep-test.org 的负责人是 DMZ DATA AS。隐私和一般问题的联络点：kontor@dmz.no。",
+      "p1": "DMZ DATA AS is the data controller for www.sleep-test.org. Privacy and general inquiries: kontor@dmz.no.",
       "p3": "Sleep-test.org 是一款关于睡眠习惯和睡眠相关挑战的自我报告工具。问题与建议参考了成熟的睡眠研究、临床指南以及公开可获取的睡眠医学和公共卫生资料。本服务旨在提供指引并支持对睡眠的反思，非诊断工具。",
       "p4": "参考资料与灵感包括美国睡眠医学学会（AASM）、美国国立卫生研究院（NIH）、美国疾病控制与预防中心（CDC）、英国国家医疗服务体系（NHS）等，以及关于睡眠卫生、昼夜节律和失眠的研究。更详细的专业背景与来源请参阅网站文章。"
     }
   },
   "privacy": {
     "title": "隐私政策",
-    "p1": "我们非常重视隐私。本政策解释了您使用 www.sleep-test.org 时我们如何处理信息。使用本网站即表示您确认已阅读并接受这些条款。本网站的设计可供学校使用，无需提供任何个人信息。",
-    "li1": "处理的数据：我们不收集姓名、电子邮件地址或其他可直接识别的信息。为了显示和保存结果，只会存储一个系统生成的 ID 以及答案摘要。我们不使用营销 cookie、第三方跟踪脚本或用户画像。",
-    "li2": "目的和法律依据：目的是提供服务并提高质量。法律依据是合法利益（GDPR 第 6(1)(f) 条），确保在不处理个人数据的情况下运营一个安全且功能正常的解决方案。技术日志可能会用于故障排除和安全。",
-    "li3": "存储与删除：技术 ID 和结果摘要只会存储到实现既定目的所需的时间为止。如果您认为内容应被删除，可以通过 kontor@dmz.no 联系我们。",
-    "li4": "共享与传输：我们不会与第三方共享数据。如果我们使用分包商（数据处理者）进行运营，他们将被合同要求保护数据，并且不得将其用于自己的目的。",
-    "li5": "学校使用与儿童：学校可以在无需提供学生数据的情况下使用本服务。教师和学生无需注册即可阅读和使用本网站。除技术运行严格必要的数据外，不会处理任何个人数据。",
-    "li6": "Cookies：我们不使用不必要的 cookies。如果未来引入功能性 cookies（例如语言偏好），我们会更新本政策并在需要时征得同意。",
-    "li7": "您的权利与联系方式：如果您有疑问、希望访问技术信息或请求删除，请通过 kontor@dmz.no 联系我们。您也可以向挪威数据保护局（Datatilsynet）投诉。",
-    "li8": "变更：我们可能在需要时更新本政策。重大更改将会在此发布。"
+    "p1": "We take privacy seriously. This policy explains how information is processed when you use www.sleep-test.org, what choices you have, and your rights under the GDPR and Norwegian privacy law.",
+    "li1": "What data we process: When you complete the test, we store a system-generated ID with a summary of answers so results can be reopened later. We do not ask for your name or email. IP address and technical events may be processed in security logs for operations and abuse prevention.",
+    "li2": "Purpose and legal basis: (a) Provide and secure the service (GDPR Art. 6(1)(f), legitimate interests). (b) Measurement/analytics and advertising technologies are used only on the basis of valid consent (GDPR Art. 6(1)(a), and the Norwegian Electronic Communications Act § 3-15 for storage/access on user devices).",
+    "li3": "Storage and deletion: Test IDs and result summaries are stored only as long as needed for the purpose, or until deletion is requested. Technical logs are retained for a limited period for security and troubleshooting.",
+    "li4": "Recipients and transfers: We use processors for hosting and operations. If you consent to analytics/advertising, Google may receive data as an independent or joint controller depending on service configuration. Data may be processed outside the EEA using relevant transfer mechanisms (for example SCCs).",
+    "li5": "School use and children: The service can be used without registration. Please do not enter names or other directly identifying data in free-text fields (if such fields are introduced later).",
+    "li6": "Cookies and consent: Necessary technologies are used so the service can function. Analytics and advertising technologies are activated only after valid consent in the consent solution. You can withdraw consent at any time by changing your consent choices.",
+    "li7": "Your rights: You can request access, rectification, deletion, restriction, data portability, and object where applicable. Contact us at kontor@dmz.no. You may also lodge a complaint with Datatilsynet.",
+    "li8": "Changes: We may update this policy when needed. Material changes will be published here with an updated date."
   },
   "test": {
     "title": "睡眠测试",


### PR DESCRIPTION
### Motivation
- Integrate Google Ads and Funding Choices consent flow to enable advertising while keeping analytics/ads dormant until consent is given.
- Provide a publisher `ads.txt` entry for ad inventory verification.
- Harmonize the `about` and `privacy` copy across multiple locale files to a clearer, English-first privacy description and updated data-controller wording.

### Description
- Added Google ad/consent integration to `www/app/layout.tsx`, including a `google-adsense-account` meta tag, a default `gtag('consent', 'default', ...)` script (denying ad and analytics storage by default), Funding Choices script, a presence iframe shim, Google Analytics `gtag` loader, and the AdSense `adsbygoogle.js` script with `crossOrigin="anonymous"`.
- Added `www/public/ads.txt` with the publisher record `google.com, pub-2004312209927228, DIRECT, f08c47fec0942fa0`.
- Updated numerous locale JSON files under `www/public/locales/*` to replace or standardize the `about` section `title`/`intro` and to replace the privacy policy body with a consistent English wording that clarifies data processing, legal basis, consent for analytics/ads, storage, recipients/transfers and rights; the Norwegian (`nb.json`) copy was updated to a Norwegian-language variant with corresponding policy changes.

### Testing
- Performed a production build with `next build` to validate SSR/SSR entry changes and the new scripts in `layout.tsx`, which completed successfully.
- Ran `npm run lint` and TypeScript typecheck (`npm run typecheck`) to validate code style and types, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da5c93142c8323938e59cfca502fb9)