### PR TITLE
Improve robots.txt directives for Google AdSense crawler access

### DIFF
--- a/www/public/robots.txt
+++ b/www/public/robots.txt
@@ -1,2 +1,7 @@
 User-agent: *
+Allow: /
+
+User-agent: Mediapartners-Google
+Allow: /
+
 Sitemap: https://sleep-test.org/sitemap.xml


### PR DESCRIPTION
### Motivation
- Make crawler access intent explicit for Google AdSense validation by allowing all bots and explicitly permitting the `Mediapartners-Google` crawler while preserving the existing sitemap and SEO settings.

### Description
- Update `www/public/robots.txt` to add `Allow: /` for `User-agent: *` and add a `User-agent: Mediapartners-Google` section with `Allow: /`; no other files were modified.

### Testing
- Verified `public/robots.txt` and `public/ads.txt` contents, confirmed `app/layout.tsx` includes `robots: { index: true, follow: true }` and the `google-adsense-account` meta tag, and successfully committed the change and created the PR with the applied commands (all automated checks completed without error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5a88f536c8323aa5bb80d4333d391)